### PR TITLE
Adds better error handling to the Wikitude iOS PhoneGap Plugin.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -99,11 +99,12 @@
         <header-file src="src/ios/WTARViewController.h" />
         <source-file src="src/ios/WTARViewController.m" />
 
+        <header-file src="src/ios/WikitudeSDK.h" />
         <header-file src="src/ios/WTArchitectView.h" />
         <header-file src="src/ios/WTNavigation.h" />
         <header-file src="src/ios/WTStartupConfiguration.h" />
-        
-        <header-file src="src/ios/WikitudeSDK.h" />
+        <header-file src="src/ios/WTArchitectViewDebugDelegate.h" />
+
 
         <source-file src="src/ios/libWikitudeSDK.a" framework="true" />
 

--- a/src/ios/WTARViewController.h
+++ b/src/ios/WTARViewController.h
@@ -16,9 +16,13 @@ extern NSString * const WTArchitectInvokedURLNotification;
 extern NSString * const WTArchitectDidCaptureScreenNotification;
 extern NSString * const WTArchitectDidFailToCaptureScreenNotification;
 
+extern NSString * const WTArchitectDebugDelegateNotification;
+
 extern NSString * const WTArchitectNotificationURLKey;
 extern NSString * const WTArchitectNotificationContextKey;
 extern NSString * const WTArchitectNotificationErrorKey;
+
+extern NSString * const WTArchitectDebugDelegateMessageKey;
 
 
 
@@ -32,7 +36,7 @@ extern NSString * const WTArchitectNotificationErrorKey;
 @end
 
 
-@interface WTArchitectViewController : UIViewController <WTArchitectViewDelegate>
+@interface WTArchitectViewController : UIViewController <WTArchitectViewDelegate, WTArchitectViewDebugDelegate>
 
 @property (nonatomic, weak) id<WTArchitectViewControllerDelegate>       architectDelegate;
 @property (nonatomic, readonly) WTArchitectView                         *architectView;

--- a/src/ios/WTARViewController.m
+++ b/src/ios/WTARViewController.m
@@ -7,6 +7,7 @@
 
 #import "WTARViewController.h"
 #import "WTArchitectView.h"
+#import "WTArchitectViewDebugDelegate.h"
 
 
 NSString * const WTArchitectDidLoadWorldNotification = @"WTArchitectDidLoadWorldNotification";
@@ -15,9 +16,13 @@ NSString * const WTArchitectInvokedURLNotification = @"WTArchitectInvokedURLNoti
 NSString * const WTArchitectDidCaptureScreenNotification = @"WTArchitectDidCaptureScreenNotification";
 NSString * const WTArchitectDidFailToCaptureScreenNotification = @"WTArchitectDidFailToCaptureScreenNotification";
 
+NSString * const WTArchitectDebugDelegateNotification = @"WTArchitectDebugDelegateNotification";
+
 NSString * const WTArchitectNotificationURLKey = @"URL";
 NSString * const WTArchitectNotificationContextKey = @"Context";
 NSString * const WTArchitectNotificationErrorKey = @"Error";
+
+NSString * const WTArchitectDebugDelegateMessageKey = @"WTArchitectDebugDelegateMessageKey";
 
 
 
@@ -39,6 +44,7 @@ NSString * const WTArchitectNotificationErrorKey = @"Error";
         
         self.architectView = [[WTArchitectView alloc] initWithFrame:[[UIScreen mainScreen] bounds] motionManager:motionManagerOrNil];
         self.architectView.delegate = self;
+        self.architectView.debugDelegate = self;
         
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceivedDeviceWillResignActiveNotification:) name:UIApplicationWillResignActiveNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceivedDeviceDidBecomeActiveNotification:) name:UIApplicationDidBecomeActiveNotification object:nil];
@@ -160,6 +166,17 @@ NSString * const WTArchitectNotificationErrorKey = @"Error";
 - (void)architectView:(WTArchitectView *)architectView willPresentViewController:(UIViewController *)presentedViewController onViewController:(UIViewController *)presentingViewController
 {
     /* Intentionally left blank */
+}
+
+#pragma mark WTArchitectViewDebugDelegate
+- (void)architectView:(WTArchitectView *)architectView didEncounterInternalWarning:(WTWarning *)warning
+{
+    /* Intentionally Left Blank */
+}
+
+- (void)architectView:(WTArchitectView *)architectView didEncounterInternalError:(NSError *)error
+{
+    [[NSNotificationCenter defaultCenter] postNotificationName:WTArchitectDebugDelegateNotification object:self userInfo:@{WTArchitectDebugDelegateMessageKey: error}];
 }
 
 

--- a/www/WikitudePlugin.js
+++ b/www/WikitudePlugin.js
@@ -161,6 +161,20 @@
     {
 		cordova.exec(successCallback, errorCallback, "WikitudePlugin", "captureScreen", [includeWebView, imagePathInBundleOrNullForPhotoLibrary]);
 	};
+	
+	/**
+	 * Use this function to set a callback that is called every time the Wikitude SDK encounters an internal error or warning. 
+	 * Internal errors can occur at any time and might not be related to any WikitudePlugin function invocation.
+	 * An error code and message are passed in form of a JSON object.
+	 *
+	 *  @param {function(jsonObject)}  errorHandler  function which is called every time the SDK encounters an internal error.
+	 *
+	 * NOTE: The errorHandler is currently only called by the Wikitude iOS SDK!
+	 */
+	WikitudePlugin.prototype.setErrorHandler = function(errorHandler)
+	{
+		cordova.exec(this.onWikitudeOK, errorHandler, "WikitudePlugin", "setErrorHandler", []);
+	}
 
 	/*
 	 *	=============================================================================================================================


### PR DESCRIPTION
Use setErrorHandler(errorHandlerFn) to receive a callback each time the Wikitude iOS SDK encounters an internal error.